### PR TITLE
[COOK-3750] allow bypassing installation of rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ These attributes are used in the `nginx::passenger` recipe.
 
 - `node['nginx']['passenger']['version']` - passenger gem version
 - `node['nginx']['passenger']['root']` - passenger gem root path
+- `node['nginx']['passenger']['install_rake']` - set to false if rake already present on system
 - `node['nginx']['passenger']['max_pool_size']` - maximum passenger
   pool size (default=10)
 - `node['nginx']['passenger']['ruby']` - Ruby path for Passenger to

--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -32,7 +32,7 @@ else
   node.default['nginx']['passenger']['root'] = "/usr/lib/ruby/gems/1.8/gems/passenger-#{node['nginx']['passenger']['version']}"
   node.default['nginx']['passenger']['ruby'] = '/usr/bin/ruby'
 end
-
+node.default['nginx']['passenger']['install_rake'] = true
 node.default['nginx']['passenger']['spawn_method'] = 'smart-lv2'
 node.default['nginx']['passenger']['buffer_response'] = 'on'
 node.default['nginx']['passenger']['max_pool_size'] = 6

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -30,7 +30,6 @@ default['nginx']['source']['default_configure_flags'] = %W[
                                                           --conf-path=#{node['nginx']['dir']}/nginx.conf
                                                           --sbin-path=#{node['nginx']['source']['sbin_path']}
                                                         ]
-
 default['nginx']['configure_flags']    = []
 default['nginx']['source']['version']  = node['nginx']['version']
 default['nginx']['source']['url']      = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"

--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -26,7 +26,9 @@ packages.each do |name|
   package name
 end
 
-gem_package 'rake'
+if node['nginx']['passenger']['install_rake']
+  gem_package 'rake'
+end
 
 gem_package 'passenger' do
   action     :install


### PR DESCRIPTION
The installation of rake is not necessary when compiling nginx/passenger for ruby 2.0+.  I've added a new attribute which allows a user to bypass this installation.  I only have about 3 days of chef experience--I'm not sure if this is the most appropriate approach, but it seems reasonable to me.  Thoughts?