### PR TITLE
Allow Version for Package Installations.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,3 +99,4 @@ default['nginx']['types_hash_bucket_size'] = 64
 default['nginx']['proxy_read_timeout']      = nil
 default['nginx']['client_body_buffer_size'] = nil
 default['nginx']['client_max_body_size']    = nil
+default['nginx']['ssl_protocols'] = ["TLSv1" ,"TLSv1.1","TLSv1.2"]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@
 # This attribute is in the source.rb file, though we recommend overriding
 # attributes by modifying a role, or the node itself.
 default['nginx']['version']      = '1.2.9'
+default['nginx']['pkg_version'] = '1.4.1-1.el6.ngx'
 default['nginx']['package_name'] = 'nginx'
 default['nginx']['dir']          = '/etc/nginx'
 default['nginx']['script_dir']   = '/usr/sbin'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.7'
+version           '2.0.9'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.5'
+version           '2.0.6'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.6'
+version           '2.0.7'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -39,7 +39,7 @@ elsif platform_family?('debian')
 end
 
 package node['nginx']['package_name'] do
-  version node['nginx']['version']
+  version node['nginx']['pkg_version']
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -39,6 +39,7 @@ elsif platform_family?('debian')
 end
 
 package node['nginx']['package_name'] do
+  version node['nginx']['version']
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -21,6 +21,7 @@ events {
 }
 
 http {
+  ssl_protocols <%= node['nginx']['ssl_protocols'].join(" ")%>;
   <% if node.recipe?('nginx::naxsi_module') %>
   include       <%= node['nginx']['dir'] %>/naxsi_core.rules;
   <% end %>


### PR DESCRIPTION
The recipe, as is, will install the latest stable release. It would be a good feature to specify the package version installed.