### PR TITLE
COOK-4033 only set http_realip_recursive if nginx version is > 1.2.1

### DIFF
--- a/templates/default/modules/http_realip.conf.erb
+++ b/templates/default/modules/http_realip.conf.erb
@@ -2,4 +2,6 @@
 set_real_ip_from <%= address %>;
 <% end %>
 real_ip_header <%= node['nginx']['realip']['header'] %>;
+<% if node['nginx']['version'] >= '1.2.1' -%>
 real_ip_recursive <%= node['nginx']['realip']['real_ip_recursive'] %>;
+<% end -%>


### PR DESCRIPTION
Per http://wiki.nginx.org/HttpRealipModule, the real_ip_recursive parameter is only available in nginx > 1.2.1