### PR TITLE
Package version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@
 # attributes by modifying a role, or the node itself.
 default['nginx']['version']      = '1.2.9'
 default['nginx']['package_name'] = 'nginx'
+default['nginx']['package_version'] = '1.4.4-1.el6.ngx'
 default['nginx']['dir']          = '/etc/nginx'
 default['nginx']['script_dir']   = '/usr/sbin'
 default['nginx']['log_dir']      = '/var/log/nginx'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.5'
+version           '2.0.6'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.6'
+version           '2.0.7'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.7'
+version           '2.0.5'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -39,7 +39,7 @@ elsif platform_family?('debian')
 end
 
 package node['nginx']['package_name'] do
-  version node['nginx']['pkg_version']
+  version node['nginx']['package_version']
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -38,13 +38,6 @@ elsif platform_family?('debian')
   end
 end
 
-ruby_block "debug nginx version" do
-  block do
-  `echo "Nginx Version: #{node['nginx']['version']}" >> /tmp/debug_chef`  
-  puts "Nginx Version: #{node['nginx']['version']}"
-  end
-end
-
 package node['nginx']['package_name'] do
   version node['nginx']['pkg_version']
   notifies :reload, 'ohai[reload_nginx]', :immediately

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -38,8 +38,15 @@ elsif platform_family?('debian')
   end
 end
 
+ruby_block "debug nginx version" do
+  block do
+  `echo "Nginx Version: #{node['nginx']['version']}" >> /tmp/debug_chef`  
+  puts "Nginx Version: #{node['nginx']['version']}"
+  end
+end
+
 package node['nginx']['package_name'] do
-  version node['nginx']['version']
+  version node['nginx']['pkg_version']
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -39,6 +39,7 @@ elsif platform_family?('debian')
 end
 
 package node['nginx']['package_name'] do
+  version node['nginx']['version']
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 


### PR DESCRIPTION
It seems that the community cookbook was truncating the ['nginx']['version'] attribute to be the format *.*.* ... This caused problems in our recipe. If we use a different attribute name, the truncation doesn't happen and the recipe does not fail. Yay!