### PR TITLE
Allow the user to pass a site template file

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -21,6 +21,14 @@
 
 define :nginx_site, :enable => true, :timing => :delayed do
   if params[:enable]
+    
+    if params[:template]
+      template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
+        source params[:template]
+        variables (params[:variables])
+      end
+    end
+    
     execute "nxensite #{params[:name]}" do
       command "#{node['nginx']['script_dir']}/nxensite #{params[:name]}"
       notifies :reload, 'service[nginx]', params[:timing]


### PR DESCRIPTION
This is something I started using while I was going through the Deis cookbooks: https://github.com/opdemand/deis-cookbook/blob/master/definitions/nginx_site.rb

This addition allows users to pass a template and variables to create an nginx site. I use it in a few of my own cookbooks like this:

```
nginx_site "munin" do
    template "site.erb"
    variables ({
        :listen => node.munin.port,
        :root => node.munin.www
    )}
    action :enable
end
```