### PR TITLE
Added default_listen_port to the default-site.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 - `node['nginx']['error_log_options']` - Set to a string of additional options
   to be appended to the error log directive
 - `node['nginx']['default_site_enabled']` - enable the default site
+- `node['nginx']['default_listen_port']` - default site listens on this port
 - `node['nginx']['sendfile']` - Whether to use `sendfile`. Defaults to "on".
 - `node['nginx']['install_method']` - Whether nginx is installed from
   packages or from source.

--- a/templates/default/default-site.erb
+++ b/templates/default/default-site.erb
@@ -1,5 +1,9 @@
 server {
-  listen   80;
+  <% if  node['nginx']['default_listen_port'] -%> 
+    listen <%= node['nginx']['default_listen_port'] %>;
+  <% else -%>
+    listen 80;
+  <% end -%>
   server_name  <%= node['hostname'] %>;
 
   access_log  <%= node['nginx']['log_dir'] %>/localhost.access.log;


### PR DESCRIPTION
I added the ability to change the default-site listen port.  This will allow non-standard ports to be used, flexibility of use.  This required the  default_site_enabled to be true to be used.