### PR TITLE
Add syslog module

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ These attributes are used in the `nginx::http_stub_status_module` recipe.
 - `node['nginx']['status']['port']` - The port on which nginx will
   serve the status info (default: 8090)
 
+### syslog
+These attributes are used in the `nginx::syslog_module` recipe.
+
+- `node['nginx']['syslog']['git_repo']` - The git repository url to use
+  for the syslog patches.
+- `node['nginx']['syslog']['git_revision']` - The revision on the git
+  repository to checkout.
+
 ### openssl_source
 These attributes are used in the `nginx::openssl_source` recipe.
 
@@ -349,6 +357,8 @@ attribute `node['nginx']['source']['modules']`.
   firewall for nginx.
 - `passenger` - builds the passenger gem and configuration for
   "`mod_passenger`".
+- `syslog` - enables syslog support for nginx.  This only works with
+  source builds.  See https://github.com/yaoweibin/nginx_syslog_patch
 - `upload_progress_module.rb` - builds the `upload_progress` module
   and enables it as a module when compiling nginx.
 - `openssl_source.rb` - downloads and uses custom OpenSSL source

--- a/attributes/syslog.rb
+++ b/attributes/syslog.rb
@@ -21,4 +21,4 @@
 #
 
 default['nginx']['syslog']['git_repo']     = "https://github.com/yaoweibin/nginx_syslog_patch.git"
-default['nginx']['syslog']['git_revision'] = "v0.25"
+default['nginx']['syslog']['git_revision'] = "master"

--- a/attributes/syslog.rb
+++ b/attributes/syslog.rb
@@ -1,0 +1,24 @@
+
+#
+# Cookbook Name:: nginx
+# Attributes:: syslog
+#
+# Author:: Bob Ziuchkovski (<bob@bz-technology.com>)
+#
+# Copyright 2014, UserTesting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['nginx']['syslog']['git_repo']     = "https://github.com/yaoweibin/nginx_syslog_patch.git"
+default['nginx']['syslog']['git_revision'] = "v0.25"

--- a/recipes/syslog_module.rb
+++ b/recipes/syslog_module.rb
@@ -43,6 +43,10 @@ when 3
   end
 when 4
   syslog_patch = "syslog_1.4.0.patch"
+when 5..6
+  syslog_patch = "syslog_1.5.6.patch"
+when 7
+  syslog_patch = "syslog_1.7.0.patch"
 else
   raise "Unsupported nginx version"
 end

--- a/recipes/syslog_module.rb
+++ b/recipes/syslog_module.rb
@@ -1,0 +1,65 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: syslog_module
+#
+# Author:: Bob Ziuchkovski (<bob@bz-technology.com>)
+#
+# Copyright 2014, UserTesting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+nginx_src = "#{Chef::Config['file_cache_path']}/nginx-#{node['nginx']['source']['version']}"
+nginx_syslog_src = "#{Chef::Config['file_cache_path']}/nginx_syslog_module"
+
+major, minor, patch = node['nginx']['source']['version'].split('.').map{ |s| Integer(s) }
+raise "Unsupported nginx version" if major != 1
+case minor
+when 2
+  case patch
+  when 0..6
+    syslog_patch = "syslog_1.2.0.patch"
+  else
+    syslog_patch = "syslog_1.2.7.patch"
+  end
+when 3
+  case patch
+  when 0..9
+    syslog_patch = "syslog_1.2.0.patch"
+  when 10..13
+    syslog_patch = "syslog_1.3.11.patch"
+  else
+    syslog_patch = "syslog_1.3.14.patch"
+  end
+when 4
+  syslog_patch = "syslog_1.4.0.patch"
+else
+  raise "Unsupported nginx version"
+end
+
+git nginx_syslog_src do
+  repository node['nginx']['syslog']['git_repo']
+  revision node['nginx']['syslog']['git_revision']
+  action :sync
+  user 'root'
+  group 'root'
+end
+
+execute 'apply_nginx_syslog_patch' do
+  cwd  nginx_src
+  command "patch -p1 < #{nginx_syslog_src}/#{syslog_patch}"
+  not_if "patch -p1 --dry-run --reverse --silent < #{nginx_syslog_src}/#{syslog_patch}", :cwd => nginx_src
+end
+
+node.run_state['nginx_configure_flags'] =
+  node.run_state['nginx_configure_flags'] | ["--add-module=#{nginx_syslog_src}"]


### PR DESCRIPTION
This PR adds support for the nginx syslog module from https://github.com/yaoweibin/nginx_syslog_patch, which is the same patch used by tengine (http://tengine.taobao.org/).