### PR TITLE
Use nginx_status template instead of default template.

### DIFF
--- a/recipes/http_stub_status_module.rb
+++ b/recipes/http_stub_status_module.rb
@@ -30,7 +30,9 @@ template 'nginx_status' do
   notifies :reload, 'service[nginx]'
 end
 
-nginx_site 'nginx_status'
+nginx_site "nginx_status" do
+  template "modules/nginx_status.erb"
+end
 
 node.run_state['nginx_configure_flags'] =
   node.run_state['nginx_configure_flags'] | ['--with-http_stub_status_module']


### PR DESCRIPTION
The http_stub_status_module.rb is using the default template instead of making use of already existing nginx_status.erb. This should be fixed.