### PR TITLE
Use attribute for listen port in nginx default server template

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 - `node['nginx']['log_dir']` - Location for Nginx logs.
 - `node['nginx']['user']` - User that Nginx will run as.
 - `node['nginx']['group]` - Group for Nginx.
+- `node['nginx']['port']` - Port for nginx to listen on.
 - `node['nginx']['binary']` - Path to the Nginx binary.
 - `node['nginx']['init_style']` - How to run Nginx as a service when
   using `nginx::source`. Values can be "runit", "upstart", "init" or

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@
 # attributes by modifying a role, or the node itself.
 default['nginx']['version']      = '1.4.4'
 default['nginx']['package_name'] = 'nginx'
+default['nginx']['port']         = '8080'
 default['nginx']['dir']          = '/etc/nginx'
 default['nginx']['script_dir']   = '/usr/sbin'
 default['nginx']['log_dir']      = '/var/log/nginx'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@
 # attributes by modifying a role, or the node itself.
 default['nginx']['version']      = '1.4.4'
 default['nginx']['package_name'] = 'nginx'
-default['nginx']['port']         = '8080'
+default['nginx']['port']         = '80'
 default['nginx']['dir']          = '/etc/nginx'
 default['nginx']['script_dir']   = '/usr/sbin'
 default['nginx']['log_dir']      = '/var/log/nginx'

--- a/templates/default/default-site.erb
+++ b/templates/default/default-site.erb
@@ -1,5 +1,5 @@
 server {
-  listen   80;
+  listen   <%= node['nginx']['port'] -%>;
   server_name  <%= node['hostname'] %>;
 
   access_log  <%= node['nginx']['log_dir'] %>/localhost.access.log;


### PR DESCRIPTION
Deals with the same issue that opscode-cookbooks/nginx#201 offers to provide, but following Chef convention more closely (as per @eherot’s [comment on the abovementioned PR](https://github.com/opscode-cookbooks/nginx/pull/201/files#r12709685)).