### PR TITLE
[COOK-4685] Set pid to /run/nginx.pid on Ubuntu 14.04

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,10 +31,15 @@ default['nginx']['log_dir']      = '/var/log/nginx'
 default['nginx']['binary']       = '/usr/sbin/nginx'
 default['nginx']['default_root'] = '/var/www/nginx-default'
 
+default['nginx']['pid'] = '/var/run/nginx.pid'
+
 case node['platform_family']
 when 'debian'
   default['nginx']['user']       = 'www-data'
   default['nginx']['init_style'] = 'runit'
+  if platform == 'ubuntu' && platform_version == '14.04'
+    default['nginx']['pid'] = '/run/nginx.pid'
+  end
 when 'rhel', 'fedora'
   default['nginx']['user']        = 'nginx'
   default['nginx']['init_style']  = 'init'
@@ -59,8 +64,6 @@ default['nginx']['upstart']['respawn_limit'] = nil
 default['nginx']['upstart']['foreground']    = true
 
 default['nginx']['group'] = node['nginx']['user']
-
-default['nginx']['pid'] = '/var/run/nginx.pid'
 
 default['nginx']['gzip']              = 'on'
 default['nginx']['gzip_static']       = 'off'


### PR DESCRIPTION
This pull requests sets the `pid` attribute in the default attributes to the new `/run/nginx.pid` on Ubuntu 14.04.

https://tickets.opscode.com/browse/COOK-4685

Please advice on a better way to do the platform and version checking.