### PR TITLE
removed conf.d include

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -76,6 +76,5 @@ http {
   limit_req_zone $binary_remote_addr zone=<%= node['nginx']['rate_limiting_zone_name'] %>:<%= node['nginx']['rate_limiting_backoff'] %> rate=<%= node['nginx']['rate_limit'] %>;
 
   <% end -%>
-  include <%= node['nginx']['dir'] %>/conf.d/*.conf;
   include <%= node['nginx']['dir'] %>/sites-enabled/*;
 }


### PR DESCRIPTION
Since we're using the 'debian' way instead of conf.d, and since on some platforms default files are *placed* in conf.d, it's probably better if we don't include it by default.