### PR TITLE
Remove confd default files on RHEL

### DIFF
--- a/recipes/commons_dir.rb
+++ b/recipes/commons_dir.rb
@@ -47,3 +47,11 @@ end
     mode  '0755'
   end
 end
+
+if node['nginx']['default_site_enabled'] && (node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora')
+  %w(default.conf example_ssl.conf).each do |config|
+    file "/etc/nginx/conf.d/#{config}" do
+      action :delete
+    end
+  end
+end

--- a/recipes/commons_dir.rb
+++ b/recipes/commons_dir.rb
@@ -48,7 +48,7 @@ end
   end
 end
 
-if node['nginx']['default_site_enabled'] && (node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora')
+if !node['nginx']['default_site_enabled'] && (node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora')
   %w(default.conf example_ssl.conf).each do |config|
     file "/etc/nginx/conf.d/#{config}" do
       action :delete


### PR DESCRIPTION
Default rpm's generate these files under conf.d and the files are loaded by default. 

default.conf is problematic because it actually makes nginx listen on port 80, example_ssl.conf is commented out.


