### PR TITLE
Expose large_client_header_buffers as configuration option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -104,7 +104,8 @@ default['nginx']['default_site_enabled']   = true
 default['nginx']['types_hash_max_size']    = 2_048
 default['nginx']['types_hash_bucket_size'] = 64
 
-default['nginx']['proxy_read_timeout']      = nil
-default['nginx']['client_body_buffer_size'] = nil
-default['nginx']['client_max_body_size']    = nil
-default['nginx']['default']['modules']      = []
+default['nginx']['proxy_read_timeout']          = nil
+default['nginx']['client_body_buffer_size']     = nil
+default['nginx']['client_max_body_size']        = nil
+default['nginx']['large_client_header_buffers'] = nil
+default['nginx']['default']['modules']          = []

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -71,6 +71,9 @@ http {
   <% if node['nginx']['client_max_body_size'] -%>
   client_max_body_size <%= node['nginx']['client_max_body_size'] %>;
   <% end -%>
+  <% if node['nginx']['large_client_header_buffers'] -%>
+  large_client_header_buffers <%= node['nginx']['large_client_header_buffers'] %>;
+  <% end -%>
 
   <% if node['nginx']['enable_rate_limiting'] -%>
   limit_req_zone $binary_remote_addr zone=<%= node['nginx']['rate_limiting_zone_name'] %>:<%= node['nginx']['rate_limiting_backoff'] %> rate=<%= node['nginx']['rate_limit'] %>;


### PR DESCRIPTION
http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers

This adds support to configure this via the nginx cookbook.