### PR TITLE
Add documentation of gzip_static configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Rate Limiting
 - `node['nginx']['gzip_types']` - used for config value of `gzip_types` - must be an Array.
 - `node['nginx']['gzip_min_length']` - used for config value of `gzip_min_length`.
 - `node['nginx']['gzip_disable']` - used for config value of `gzip_disable`.
-
+- `node['nginx']['gzip_static']` - used for config value of `gzip_static` (`http_gzip_static_module` must be enabled)
 ### Attributes set in recipes
 
 #### nginx::source
@@ -338,7 +338,7 @@ attribute `node['nginx']['source']['modules']`.
   enables it as a module when compiling nginx.
 - `http_geoip_module.rb` - installs the GeoIP libraries and data files
   and enables the module for compilation.
-- `http_gzip_static_module.rb` - enables the module for compilation.
+- `http_gzip_static_module.rb` - enables the module for compilation. Be sure to set `node['nginx']['gzip_static'] = 'yes'`.
 - `http_perl_module.rb` - enables embedded Perl for compilation.
 - `http_realip_module.rb` - enables the module for compilation and
   creates the configuration.


### PR DESCRIPTION
The attribute was added (https://github.com/miketheman/nginx/commit/aa68b47717b2b ) but it was not documented in the README. I had to dig for it.

I wonder if adding http_gzip_static_module should set `node['nginx']['gzip_static'] = 'yes'` by default? That seems like the principle of least surprise. It took me a while to figure out why my .gz files were not being served even though I had enabled the module.