### PR TITLE
Correct passenger curl dependencies for RHEL-famly v6+

### DIFF
--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -33,7 +33,7 @@ else
   node.default['nginx']['passenger']['ruby'] = '/usr/bin/ruby'
 end
 
-node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel)
+node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel libcurl-devel)
 node.default['nginx']['passenger']['packages']['debian'] = %w(ruby-dev libcurl4-gnutls-dev)
 
 node.default['nginx']['passenger']['spawn_method'] = 'smart-lv2'

--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -33,7 +33,11 @@ else
   node.default['nginx']['passenger']['ruby'] = '/usr/bin/ruby'
 end
 
-node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel libcurl-devel)
+if platform_family?('rhel') && node['platform_version'].to_i == 6
+  node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel libcurl-devel)
+else
+  node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel)
+end
 node.default['nginx']['passenger']['packages']['debian'] = %w(ruby-dev libcurl4-gnutls-dev)
 
 node.default['nginx']['passenger']['spawn_method'] = 'smart-lv2'

--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -33,7 +33,7 @@ else
   node.default['nginx']['passenger']['ruby'] = '/usr/bin/ruby'
 end
 
-if platform_family?('rhel') && node['platform_version'].to_i == 6
+if platform_family?('rhel') && node['platform_version'].to_i >= 6
   node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel libcurl-devel)
 else
   node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel)


### PR DESCRIPTION
As of RHEL 6, `curl-devel` no longer exists and is replaced with `libcurl-devel`. `yum` will still resolve the dependency, but must then do so by effectively doing a 'provides' scan of all the configured repositories for the host, potentially consuming a large amount of system memory depending on yum repositories configured. For example, on low-memory (<1GB) Oracle Enterprise 6 hosts, yum will actually run the system out of memory while trying to resolve `curl-devel`.