### PR TITLE
Ensure socketproxy requests to static files work

### DIFF
--- a/templates/default/modules/socketproxy.conf.erb
+++ b/templates/default/modules/socketproxy.conf.erb
@@ -45,7 +45,7 @@
 
     location ^~ /<%= app_conf['context_name'] %> {
 
-      alias $app_home/<%= app %>/<%= app_conf['subdir'] %>/public;
+      alias $app_home/<%= app %>/<%= app_conf['subdir'] %>/public/;
 
       try_files $uri/index.html $uri.html $uri @app_<%= app %>;
       error_page 404              /404.html;


### PR DESCRIPTION
Without this slash, requests would end up going to:

`$app_home/app/subdir/public$uri`

instead of:

`$app_home/app/subdir/public/$uri`