### PR TITLE
Remove duplicate resources

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,10 @@
 
 include_recipe "nginx::#{node['nginx']['install_method']}"
 
-resources(:service => 'nginx').action :start
+ruby_block 'start nginx' do
+  block {}
+  notifies :start, 'service[nginx]'
+end
 
 node['nginx']['default']['modules'].each do |ngx_module|
   include_recipe "nginx::#{ngx_module}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,10 +21,7 @@
 
 include_recipe "nginx::#{node['nginx']['install_method']}"
 
-service 'nginx' do
-  supports :status => true, :restart => true, :reload => true
-  action   :start
-end
+resources(:service => 'nginx').action :start
 
 node['nginx']['default']['modules'].each do |ngx_module|
   include_recipe "nginx::#{ngx_module}"

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -38,4 +38,9 @@ when 'debian'
     deb_src      true
     key          'http://nginx.org/keys/nginx_signing.key'
   end
+
+  ruby_block 're-run apt-get update' do
+    block {}
+    notifies :run, 'execute[apt-get update]'
+  end
 end


### PR DESCRIPTION
This causes the nginx cookbook to throw a lot fewer "resource cloned" warnings during convergence.