### PR TITLE
Fixes #281, default attribute for ssl_protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 * `node['nginx']['sts_max_age']` - Enable Strict Transport Security for all apps (See: http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security).  This attribute adds the following header:
 
   Strict-Transport-Security max-age=SECONDS
-
 to all incoming requests and takes an integer (in seconds) as its argument.
+- `node['nginx']['ssl_protocols']` - Define a sane default set of SSL
+  protocols that consumers of this cookbook can use in their own
+  templates.
 * `node['nginx']['default']['modules']` - Array specifying which
 modules to enable via the conf-enabled config include function.
 Currently the only valid value is "socketproxy".

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,3 +108,5 @@ default['nginx']['proxy_read_timeout']      = nil
 default['nginx']['client_body_buffer_size'] = nil
 default['nginx']['client_max_body_size']    = nil
 default['nginx']['default']['modules']      = []
+
+default['nginx']['ssl_protocols']           = 'TLSv1 TLSv1.1 TLSv1.2'


### PR DESCRIPTION
This commit adds a default-precedence attribute for SSL protocols to be defined and consumed by others who use this cookbook. One would use this in a config template:

```
ssl_protocols <%= node['nginx']['ssl_protocols'] %>;
```