### PR TITLE
Mitigate POODLE vulnerability

### DIFF
--- a/attributes/ssl.rb
+++ b/attributes/ssl.rb
@@ -1,0 +1,1 @@
+default['nginx']['ssl_protocols'] = ['TLSv1', 'TLSv1.1', 'TLSv1.2']

--- a/recipes/http_ssl_module.rb
+++ b/recipes/http_ssl_module.rb
@@ -23,7 +23,7 @@ node.run_state['nginx_configure_flags'] =
   node.run_state['nginx_configure_flags'] | ['--with-http_ssl_module']
 
 file "#{node['nginx']['dir']}/conf.d/poodle_vuln.conf" do
-  content "ssl_protocols #{node['nginx']['ssl_protocols'].join(' ')}"
+  content "ssl_protocols #{node['nginx']['ssl_protocols'].join(' ')};"
   owner  'root'
   group  node['root_group']
   mode   '0644'

--- a/recipes/http_ssl_module.rb
+++ b/recipes/http_ssl_module.rb
@@ -21,3 +21,11 @@
 
 node.run_state['nginx_configure_flags'] =
   node.run_state['nginx_configure_flags'] | ['--with-http_ssl_module']
+
+file "#{node['nginx']['dir']}/conf.d/poodle_vuln.conf" do
+  content "ssl_protocols #{node['nginx']['ssl_protocols'].join(' ')}"
+  owner  'root'
+  group  node['root_group']
+  mode   '0644'
+  notifies :reload, 'service[nginx]'
+end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -49,3 +49,6 @@ service 'nginx' do
 end
 
 include_recipe 'nginx::commons'
+
+# Ensure POODLE vulnerability is patched.
+include_recipe 'nginx::http_ssl_module'


### PR DESCRIPTION
Ref: #281

The recipe `nginx::auth_ssl_module` technically seemed to be for compiling from source (as mentioned in readme), but this seemed like the most sensible approach. Let me know if it looks ok, and I'll update the docs before we merge.