### PR TITLE
Fix fedora nginx::sources recipe error

### DIFF
--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -34,7 +34,7 @@ else
 end
 
 node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel)
-node.default['nginx']['passenger']['packages']['fedora'] = %w(ruby-devel curl-devel)
+node.default['nginx']['passenger']['packages']['fedora'] = %w(ruby-devel libcurl-devel)
 node.default['nginx']['passenger']['packages']['debian'] = %w(ruby-dev libcurl4-gnutls-dev)
 
 node.default['nginx']['passenger']['spawn_method'] = 'smart-lv2'

--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -34,6 +34,7 @@ else
 end
 
 node.default['nginx']['passenger']['packages']['rhel'] = %w(ruby-devel curl-devel)
+node.default['nginx']['passenger']['packages']['fedora'] = %w(ruby-devel curl-devel)
 node.default['nginx']['passenger']['packages']['debian'] = %w(ruby-dev libcurl4-gnutls-dev)
 
 node.default['nginx']['passenger']['spawn_method'] = 'smart-lv2'

--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -19,6 +19,7 @@
 
 packages = value_for_platform_family(
   %w(rhel)   => node['nginx']['passenger']['packages']['rhel'],
+  %w(fedora)   => node['nginx']['passenger']['packages']['fedora'],
   %w(debian) => node['nginx']['passenger']['packages']['debian']
 )
 


### PR DESCRIPTION
Error when running nginx::sources recipe on Fedora:

```
  ================================================================================
  Recipe Compile Error in /root/.chef/local-mode-cache/cache/cookbooks/nginx/recipes/source.rb
  ================================================================================
  
  NoMethodError
  -------------
  undefined method `empty?' for nil:NilClass
  
  Cookbook Trace:
  ---------------
    /root/.chef/local-mode-cache/cache/cookbooks/nginx/recipes/passenger.rb:25:in `from_file'
    /root/.chef/local-mode-cache/cache/cookbooks/nginx/recipes/source.rb:91:in `block in from_file'
    /root/.chef/local-mode-cache/cache/cookbooks/nginx/recipes/source.rb:90:in `each'
    /root/.chef/local-mode-cache/cache/cookbooks/nginx/recipes/source.rb:90:in `from_file'
  
  Relevant File Content:
  ----------------------
  /root/.chef/local-mode-cache/cache/cookbooks/nginx/recipes/passenger.rb:
  
   18:  #
   19:  
   20:  packages = value_for_platform_family(
   21:    %w(rhel)   => node['nginx']['passenger']['packages']['rhel'],
   22:    %w(debian) => node['nginx']['passenger']['packages']['debian']
   23:  )
   24:  
   25>> unless packages.empty?
   26:    packages.each do |name|
   27:      package name
   28:    end
   29:  end
   30:  
   31:  gem_package 'rake'
   32:  
   33:  gem_package 'passenger' do
   34:    action     :install
```