### PR TITLE
add support for log formats

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,6 +99,7 @@ default['nginx']['sendfile'] = 'on'
 default['nginx']['access_log_options']     = nil
 default['nginx']['error_log_options']      = nil
 default['nginx']['disable_access_log']     = false
+default['nginx']['log_formats']            = {}
 default['nginx']['install_method']         = 'package'
 default['nginx']['default_site_enabled']   = true
 default['nginx']['types_hash_max_size']    = 2_048

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -28,6 +28,10 @@ http {
   include       <%= node['nginx']['dir'] %>/mime.types;
   default_type  application/octet-stream;
 
+  <% node['nginx']['log_formats'].each do |name, format| %>
+  log_format <%= name %> <%= format %>;
+  <% end -%>
+
   <% if node['nginx']['disable_access_log'] -%>
   access_log    off;
   <% else -%>


### PR DESCRIPTION
I want to be able to define new log formats in the nginx configuration as follows:

```
override['nginx']['log_formats'] = {
  "acc_log" => %{'$remote_addr - $remote_user [$time_local] '
                   '"$request" $status $bytes_sent '
                   '"$http_referer" "$http_user_agent" "$gzip_ratio" '
                   '"$sent_http_x_cache" $request_time'}
}
```

I've been trying to follow your contributing guidelines, I signed your ICLA, but JIRA says that the issue tracker has moved to github, so I am not sure if I'm doing it right.