### PR TITLE
8la/poodle ssl fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 * `node['nginx']['sts_max_age']` - Enable Strict Transport Security for all apps (See: http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security).  This attribute adds the following header:
 
   Strict-Transport-Security max-age=SECONDS
-
 to all incoming requests and takes an integer (in seconds) as its argument.
+- `node['nginx']['ssl_protocols']` - Define a sane default set of SSL
+  protocols that consumers of this cookbook can use in their own
+  templates.
 * `node['nginx']['default']['modules']` - Array specifying which
 modules to enable via the conf-enabled config include function.
 Currently the only valid value is "socketproxy".

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,3 +129,5 @@ default['nginx']['large_client_header_buffers'] = nil
 default['nginx']['default']['modules']          = []
 
 default['nginx']['extra_configs'] = {}
+
+default['nginx']['ssl_protocols']           = 'TLSv1 TLSv1.1 TLSv1.2'

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -98,6 +98,14 @@ http {
   <%= key %> <%= value %>;
   <% end -%>
 
+  <% if node['nginx']['install_method'] == 'package' %>
+  ssl_protocols <%= node['nginx']['ssl_protocols'] %>;
+  <% elsif node['nginx']['install_method'] == 'source' %>
+      <% if  node['nginx']['source']['modules'].include? 'nginx::http_ssl_module' %>
+  ssl_protocols <%= node['nginx']['ssl_protocols'] %>;
+      <% end %>
+  <% end -%> 
+
   include <%= node['nginx']['dir'] %>/conf.d/*.conf;
   include <%= node['nginx']['dir'] %>/sites-enabled/*.conf;
 }

--- a/test/integration/source/bats/check_service.bats
+++ b/test/integration/source/bats/check_service.bats
@@ -1,3 +1,0 @@
-@test "check nginx service" {
-      ps -ef | grep nginx
-}

--- a/test/integration/source/serverspec/source_spec.rb
+++ b/test/integration/source/serverspec/source_spec.rb
@@ -1,0 +1,12 @@
+# Encoding: utf-8
+require_relative 'spec_helper'
+
+
+describe file('/etc/nginx/nginx.conf') do
+  it { should be_a_file }
+  its(:content) { should match(%r{ssl_protocols TLSv1 TLSv1.1 TLSv1.2;}) } 
+end
+
+describe service('nginx') do
+  it { should be_running }
+end

--- a/test/integration/source/serverspec/source_spec.rb
+++ b/test/integration/source/serverspec/source_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 
 describe file('/etc/nginx/nginx.conf') do
   it { should be_a_file }
-  its(:content) { should match(%r{ssl_protocols TLSv1 TLSv1.1 TLSv1.2;}) } 
+  its(:content) { should match(/ssl_protocols TLSv1 TLSv1.1 TLSv1.2;/) }
 end
 
 describe service('nginx') do

--- a/test/integration/source/serverspec/source_spec.rb
+++ b/test/integration/source/serverspec/source_spec.rb
@@ -1,7 +1,6 @@
 # Encoding: utf-8
 require_relative 'spec_helper'
 
-
 describe file('/etc/nginx/nginx.conf') do
   it { should be_a_file }
   its(:content) { should match(/ssl_protocols TLSv1 TLSv1.1 TLSv1.2;/) }

--- a/test/integration/source/serverspec/spec_helper.rb
+++ b/test/integration/source/serverspec/spec_helper.rb
@@ -1,0 +1,10 @@
+# Encoding: utf-8
+require 'serverspec'
+require 'pathname'
+require 'json'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+set :env, :LANG => 'C', :LC_MESSAGES => 'C'
+

--- a/test/integration/source/serverspec/spec_helper.rb
+++ b/test/integration/source/serverspec/spec_helper.rb
@@ -7,4 +7,3 @@ set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
 set :env, :LANG => 'C', :LC_MESSAGES => 'C'
-


### PR DESCRIPTION
This will include ssl protocols by default on http block. 

As of sslv3 being vulnerable, it will be a good default policy to have it disabled.

The attribute has a conditional block around on the template, to check when we are on source or package install and being on source install, ensure we are using ssl module.

Inludes #282 fixes #281