### PR TITLE
Add missing extension in nginx configfile

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -77,5 +77,5 @@ http {
 
   <% end -%>
   include <%= node['nginx']['dir'] %>/conf.d/*.conf;
-  include <%= node['nginx']['dir'] %>/sites-enabled/*;
+  include <%= node['nginx']['dir'] %>/sites-enabled/*.conf;
 }


### PR DESCRIPTION
.conf is missing so the configfile is never parsed by nginx