### PR TITLE
Adds a configurable log format

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -96,6 +96,8 @@ default['nginx']['server_tokens']        = nil
 default['nginx']['server_names_hash_bucket_size'] = 64
 default['nginx']['sendfile'] = 'on'
 
+default['nginx']['log_formats'] = nil
+
 default['nginx']['access_log_options']     = nil
 default['nginx']['error_log_options']      = nil
 default['nginx']['disable_access_log']     = false

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -28,6 +28,12 @@ http {
   include       <%= node['nginx']['dir'] %>/mime.types;
   default_type  application/octet-stream;
 
+  <% unless node['nginx']['log_formats'].nil? -%>
+	<% node['nginx']['log_formats'].each do |log_name, log_format_string| %>
+  log_format <%= log_name %> '<%= log_format_string %>';
+	<% end %>
+  <% end -%>
+
   <% if node['nginx']['disable_access_log'] -%>
   access_log    off;
   <% else -%>


### PR DESCRIPTION
Added a configurable log_format hash, which will create log_format directives in
the nginx config. These can then be used in site configurations.

This is a proposed solution to Issue #293