### PR TITLE
include apt::default recipe in nginx::package instead of nginx::repo

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -34,6 +34,7 @@ if platform_family?('rhel')
     fail ArgumentError, "Unknown value '#{node['nginx']['repo_source']}' was passed to the nginx cookbook."
   end
 elsif platform_family?('debian')
+  include_recipe 'apt::default'
   include_recipe 'nginx::repo' if node['nginx']['repo_source'] == 'nginx'
 end
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -29,7 +29,6 @@ when 'rhel', 'fedora'
   end
 
 when 'debian'
-  include_recipe 'apt::default'
 
   apt_repository 'nginx' do
     uri          node['nginx']['upstream_repository']

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -45,6 +45,11 @@ describe 'nginx::package' do
   end
 
   context 'debian platform family' do
+
+    it 'includes apt recipe' do
+      expect(chef_run).to include_recipe('apt::default')
+    end
+
     context 'default attributes' do
       it_behaves_like 'all platforms'
       it_behaves_like 'package resource'

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -6,10 +6,6 @@ describe 'nginx::repo' do
       ChefSpec::SoloRunner.new(:platform => 'debian', :version => '7.0').converge(described_recipe)
     end
 
-    it 'includes apt recipe' do
-      expect(chef_run).to include_recipe('apt::default')
-    end
-
     it 'adds apt repository' do
       expect(chef_run).to add_apt_repository('nginx')
     end


### PR DESCRIPTION
Using the nginx::package recipe fails on a node with outdated apt package index.

This includes the apt::default recipe in nginx::package instead of nginx::repo which should make no difference when installing nginx from the nginx apt repository (nginx::repo recipe).

This also fixes the kitchen-vagrant suites for ubuntu.