### PR TITLE
Fixes #308 - Use access_log_options attribute to set options for socketproxy access log

### DIFF
--- a/templates/default/modules/socketproxy.conf.erb
+++ b/templates/default/modules/socketproxy.conf.erb
@@ -8,7 +8,7 @@
 
     listen <%= node['nginx']['port'] %> default;
 
-    access_log <%= node['nginx']['log_dir'] %>/<%= node['nginx']['socketproxy']['logname'] %>.access.log main;
+    access_log <%= node['nginx']['log_dir'] %>/<%= node['nginx']['socketproxy']['logname'] %>.access.log<% if node['nginx']['access_log_options'] %> <%= node['nginx']['access_log_options'] %><% end %>;
     error_log <%= node['nginx']['log_dir'] %>/<%= node['nginx']['socketproxy']['logname'] %>.error.log debug;
 
     <% if node['nginx']['server_name'] -%>


### PR DESCRIPTION
instead of assuming "main"