### PR TITLE
Set all notifies that are not ':immediately' to be ':delayed'

### DIFF
--- a/recipes/authorized_ips.rb
+++ b/recipes/authorized_ips.rb
@@ -28,5 +28,5 @@ template 'authorized_ip' do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end

--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -25,7 +25,7 @@ template 'nginx.conf' do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 template "#{node['nginx']['dir']}/sites-available/default" do
@@ -33,7 +33,7 @@ template "#{node['nginx']['dir']}/sites-available/default" do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 nginx_site 'default' do

--- a/recipes/http_realip_module.rb
+++ b/recipes/http_realip_module.rb
@@ -31,7 +31,7 @@ template "#{node['nginx']['dir']}/conf.d/http_realip.conf" do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 node.run_state['nginx_configure_flags'] =

--- a/recipes/http_stub_status_module.rb
+++ b/recipes/http_stub_status_module.rb
@@ -27,7 +27,7 @@ template 'nginx_status' do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 nginx_site 'nginx_status'

--- a/recipes/naxsi_module.rb
+++ b/recipes/naxsi_module.rb
@@ -24,7 +24,7 @@ cookbook_file "#{node['nginx']['dir']}/naxsi_core.rules" do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 naxsi_src_filename = ::File.basename(node['nginx']['naxsi']['url'])

--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -41,7 +41,7 @@ template "#{node['nginx']['dir']}/conf.d/passenger.conf" do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 node.run_state['nginx_configure_flags'] =

--- a/recipes/socketproxy.rb
+++ b/recipes/socketproxy.rb
@@ -18,7 +18,7 @@ template node['nginx']['dir'] + '/sites-available/socketproxy.conf' do
   owner 'root'
   group 'root'
   mode 00644
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 link node['nginx']['dir'] + '/sites-enabled/socketproxy.conf' do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -73,7 +73,7 @@ cookbook_file "#{node['nginx']['dir']}/mime.types" do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 # source install depends on the existence of the `tar` package

--- a/recipes/upload_progress_module.rb
+++ b/recipes/upload_progress_module.rb
@@ -36,7 +36,7 @@ template "#{node['nginx']['dir']}/conf.d/upload_progress.conf" do
   owner  'root'
   group  node['root_group']
   mode   '0644'
-  notifies :reload, 'service[nginx]'
+  notifies :reload, 'service[nginx]', :delayed
 end
 
 bash 'extract_upload_progress_module' do


### PR DESCRIPTION
Using ":delayied" allows configuration changes to wait for all parts to be deployed before restarting nginx. This is particularly helpful with new "enabled" sites conflict with old "enabled" sites which have not yet been cleared.