### PR TITLE
Configuration broken because of change how enabled sites are imported in nginx.conf

### DIFF
--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -29,7 +29,7 @@ template 'nginx.conf' do
   notifies :reload, 'service[nginx]', :delayed
 end
 
-template "#{node['nginx']['dir']}/sites-available/default" do
+template "#{node['nginx']['dir']}/sites-available/default.conf" do
   source 'default-site.erb'
   owner  'root'
   group  node['root_group']
@@ -37,6 +37,6 @@ template "#{node['nginx']['dir']}/sites-available/default" do
   notifies :reload, 'service[nginx]', :delayed
 end
 
-nginx_site 'default' do
+nginx_site 'default.conf' do
   enable node['nginx']['default_site_enabled']
 end


### PR DESCRIPTION
Because of this pull request:
https://github.com/miketheman/nginx/commit/870b4e58df829c42f9d0442ef43626806f9c253d#diff-44afc615d4a510304b5e24396c4c9100
default site is broken now.

Using `default['nginx']['default_site_enabled'] = true` will generate symlink like ex. `/etc/nginx/sites-enabled/000-default` and it won't be used (because have no .conf extension).

My pull request is rather issue report than fix for that and you may need more changes to workaround this. Ex. nxensite may require fix to add `000-` prefix to default site.

Regardless of that pull - why don't you push this cookbook without minor version number incremented? This small change may and probably will broke many configurations.