### PR TITLE
Fixing the checksums for GeoIP files

### DIFF
--- a/attributes/geoip.rb
+++ b/attributes/geoip.rb
@@ -22,9 +22,9 @@
 default['nginx']['geoip']['path']                 = '/srv/geoip'
 default['nginx']['geoip']['enable_city']          = true
 default['nginx']['geoip']['country_dat_url']      = 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz'
-default['nginx']['geoip']['country_dat_checksum'] = '79ff1099e96c2dc1c2539c9a18aaa13a9afd085cae477df60d95f1644d42bc07'
+default['nginx']['geoip']['country_dat_checksum'] = '33104eb35340c97227ea93f7ba1c84c38742a4f8adea23a3201350e9bd918795'
 default['nginx']['geoip']['city_dat_url']         = 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz'
-default['nginx']['geoip']['city_dat_checksum']    = '8a6467033a528f68b1a97de24d9d0ce86c8e8e83683820e16e433ddbd3f712f7'
+default['nginx']['geoip']['city_dat_checksum']    = 'aa005e191fff2b1e31974b79feec739ddaa35461cadc04733fff35d695498651'
 default['nginx']['geoip']['lib_version']          = '1.6.3'
 lib_version = node['nginx']['geoip']['lib_version'] # convenience variable for line length
 default['nginx']['geoip']['lib_url']              = "https://github.com/maxmind/geoip-api-c/releases/download/v#{lib_version}/GeoIP-#{lib_version}.tar.gz"


### PR DESCRIPTION
I usually just override these locally but I figured i would push the change back upstream. 

I usually override them with something like this in my default attribute file: 

```
override['nginx']['geoip']['country_dat_checksum'] = '33104eb35340c97227ea93f7ba1c84c38742a4f8adea23a3201350e9bd918795'
override['nginx']['geoip']['city_dat_checksum'] = 'aa005e191fff2b1e31974b79feec739ddaa35461cadc04733fff35d695498651'
```