### PR TITLE
Force nginx to recompile if the passenger buildout directory doesn't exist

### DIFF
--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -45,6 +45,9 @@ elsif node['nginx']['passenger']['install_method'] == 'source'
   node.run_state['nginx_configure_flags'] =
     node.run_state['nginx_configure_flags'] | ["--add-module=#{node['nginx']['passenger']['root']}/ext/nginx"]
 
+  if !Dir.exists? "#{node['nginx']['passenger']['root']}/buildout"
+    node.run_state['nginx_force_recompile'] = true
+  end
 end
 
 template "#{node['nginx']['dir']}/conf.d/passenger.conf" do


### PR DESCRIPTION
If you upgrade your ruby, but keep your passenger and nginx versions the same, the cookbook installs the new passenger gem but doesn't recompile nginx - resulting in a malfunctioning nginx with no passenger.

This small change forces an nginx recompile if the "buildout" directory for passenger doesn't exist. 