### PR TITLE
updated build-essential dependency to 2.2.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ recipe 'nginx::source', 'Installs nginx from source and sets up configuration wi
 
 depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
-depends 'build-essential', '~> 2.0'
+depends 'build-essential', '~> 2.2'
 depends 'ohai',            '~> 2.0'
 depends 'runit',           '~> 1.2'
 depends 'yum-epel',        '~> 0.3'


### PR DESCRIPTION
I have to use build-essential 2.2.x to get Solaris compatibility, but the nginx cookbooks has a dependency on build-essential 2.0.x. I updated the dependency, but for compatibility it may be better to use `>= 2.0` as version constraint.