### PR TITLE
Add support for nginx-rtmp module

### DIFF
--- a/attributes/rtmp_module.rb
+++ b/attributes/rtmp_module.rb
@@ -25,9 +25,10 @@ default['nginx']['rtmp']['source_checksum'] = '7922b0e3d5f3d9c4b275e4908cfb8f5fb
 
 default['nginx']['rtmp']['rtmp_server'] = true
 default['nginx']['rtmp']['rtmp_port'] = '1935'
-default['nginx']['rtmp']['hls_port'] = '8080'
+default['nginx']['rtmp']['http_port'] = '8080'
 default['nginx']['rtmp']['stat_port'] = '8081'
 default['nginx']['rtmp']['hls'] = false
+default['nginx']['rtmp']['dash'] = false
 default['nginx']['rtmp']['stat'] = false
 case node['platform_family']
 when 'freebsd'

--- a/attributes/rtmp_module.rb
+++ b/attributes/rtmp_module.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: rtmp_module
+#
+# Author:: Shaun Keenan (<skeenan@gmail.com>)
+#
+# Copyright 2015, Shaun Keenan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['nginx']['rtmp']['version']         = '1.1.7'
+default['nginx']['rtmp']['source_url']      = "https://github.com/arut/nginx-rtmp-module/archive/v#{node['nginx']['rtmp']['version']}.tar.gz"
+default['nginx']['rtmp']['source_checksum'] = '7922b0e3d5f3d9c4b275e4908cfb8f5fb1bfb3ac2df77f4c262cda56df21aab3'
+
+default['nginx']['rtmp']['rtmp_server'] = true
+default['nginx']['rtmp']['rtmp_port'] = '1935'
+default['nginx']['rtmp']['hls_port'] = '8080'
+default['nginx']['rtmp']['stat_port'] = '8081'
+default['nginx']['rtmp']['hls'] = false
+default['nginx']['rtmp']['stat'] = false
+case node['platform_family']
+when 'freebsd'
+  default['nginx']['rtmp']['stat_root'] = '/usr/local/www/nginx-rtmp'
+else
+  default['nginx']['rtmp']['stat_root'] = '/var/www/nginx-rtmp'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.7.6'
+version           '2.7.7'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/recipes/rtmp_module.rb
+++ b/recipes/rtmp_module.rb
@@ -73,15 +73,15 @@ remote_file "#{node['nginx']['rtmp']['stat_root']}/stat.xsl" do
   notifies :reload, 'service[nginx]', :delayed
 end
 
-template "#{node['nginx']['dir']}/sites-available/rtmp-hls" do
-  source 'modules/rtmp-hls.erb'
+template "#{node['nginx']['dir']}/sites-available/rtmp-http" do
+  source 'modules/rtmp-http.erb'
   owner  'root'
   group  node['root_group']
   mode   '0644'
   notifies :reload, 'service[nginx]', :delayed
 end
-nginx_site 'rtmp-hls' do
-  enable node['nginx']['rtmp']['hls']
+nginx_site 'rtmp-http' do
+  enable node['nginx']['rtmp']['hls'] || node['nginx']['rtmp']['dash']
 end
 template "#{node['nginx']['dir']}/sites-available/rtmp-stat" do
   source 'modules/rtmp-stat.erb'

--- a/recipes/rtmp_module.rb
+++ b/recipes/rtmp_module.rb
@@ -1,0 +1,95 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: rtmp_module
+#
+# Author:: Shaun Keenan (<skeenan@gmail.com>)
+#
+# Copyright 2015, Shaun Keenan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tar_location = "#{Chef::Config['file_cache_path']}/rtmp_module.tar.gz"
+module_location = "#{Chef::Config['file_cache_path']}/rtmp_module/#{node['nginx']['rtmp']['source_checksum']}"
+
+remote_file tar_location do
+  source   node['nginx']['rtmp']['source_url']
+  checksum node['nginx']['rtmp']['source_checksum']
+  owner    'root'
+  group    node['root_group']
+  mode     '0644'
+end
+
+directory module_location do
+  owner     'root'
+  group     node['root_group']
+  mode      '0755'
+  recursive true
+  action    :create
+end
+
+bash 'extract_rtmp' do
+  cwd  ::File.dirname(tar_location)
+  user 'root'
+  code <<-EOH
+    tar -zxf #{tar_location} -C #{module_location}
+  EOH
+  not_if { ::File.exist?("#{module_location}/rtmp-nginx-module-#{node['nginx']['rtmp']['version']}/config") }
+end
+
+node.run_state['nginx_configure_flags'] =
+    node.run_state['nginx_configure_flags'] | ["--add-module=#{module_location}/nginx-rtmp-module-#{node['nginx']['rtmp']['version']}/"]
+
+
+template "#{node['nginx']['dir']}/rtmp.conf" do
+  source 'modules/rtmp.conf.erb'
+  owner  'root'
+  group  node['root_group']
+  mode   '0644'
+  notifies :reload, 'service[nginx]', :delayed
+end
+
+directory node['nginx']['rtmp']['stat_root'] do
+  owner     'root'
+  group     node['root_group']
+  mode      '0755'
+  recursive true
+end
+
+remote_file "#{node['nginx']['rtmp']['stat_root']}/stat.xsl" do 
+  source "file://#{module_location}/nginx-rtmp-module-#{node['nginx']['rtmp']['version']}/stat.xsl"
+  owner  'root'
+  group  node['root_group']
+  mode   '0644'
+  notifies :reload, 'service[nginx]', :delayed
+end
+
+template "#{node['nginx']['dir']}/sites-available/rtmp-hls" do
+  source 'modules/rtmp-hls.erb'
+  owner  'root'
+  group  node['root_group']
+  mode   '0644'
+  notifies :reload, 'service[nginx]', :delayed
+end
+nginx_site 'rtmp-hls' do
+  enable node['nginx']['rtmp']['hls']
+end
+template "#{node['nginx']['dir']}/sites-available/rtmp-stat" do
+  source 'modules/rtmp-stat.erb'
+  owner  'root'
+  group  node['root_group']
+  mode   '0644'
+  notifies :reload, 'service[nginx]', :delayed
+end
+nginx_site 'rtmp-stat' do
+  enable node['nginx']['rtmp']['stat']
+end

--- a/recipes/rtmp_module.rb
+++ b/recipes/rtmp_module.rb
@@ -17,6 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+include_recipe 'nginx'
 
 tar_location = "#{Chef::Config['file_cache_path']}/rtmp_module.tar.gz"
 module_location = "#{Chef::Config['file_cache_path']}/rtmp_module/#{node['nginx']['rtmp']['source_checksum']}"
@@ -49,7 +50,6 @@ end
 node.run_state['nginx_configure_flags'] =
     node.run_state['nginx_configure_flags'] | ["--add-module=#{module_location}/nginx-rtmp-module-#{node['nginx']['rtmp']['version']}/"]
 
-
 template "#{node['nginx']['dir']}/rtmp.conf" do
   source 'modules/rtmp.conf.erb'
   owner  'root'
@@ -65,7 +65,7 @@ directory node['nginx']['rtmp']['stat_root'] do
   recursive true
 end
 
-remote_file "#{node['nginx']['rtmp']['stat_root']}/stat.xsl" do 
+remote_file "#{node['nginx']['rtmp']['stat_root']}/stat.xsl" do
   source "file://#{module_location}/nginx-rtmp-module-#{node['nginx']['rtmp']['version']}/stat.xsl"
   owner  'root'
   group  node['root_group']

--- a/spec/unit/recipes/rtmp_module_spec.rb
+++ b/spec/unit/recipes/rtmp_module_spec.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+describe 'nginx::rtmp_module' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set['nginx']['source']['modules'] = ['nginx::rtmp_module']
+    end.converge(described_recipe)
+  end
+
+  it 'retrieves remote files to cache' do
+    expect(chef_run).to create_remote_file("#{Chef::Config['file_cache_path']}/rtmp_module.tar.gz")
+  end
+
+  it 'creates extracted directory' do
+    rtmp_module_checksum = chef_run.node.attributes['nginx']['rtmp']['source_checksum']
+
+    expect(chef_run).to create_directory("#{Chef::Config['file_cache_path']}/rtmp_module/#{rtmp_module_checksum}")
+  end
+
+  it 'expands the retrieved files' do
+    expect(chef_run).to run_bash('extract_rtmp')
+  end
+end

--- a/spec/unit/recipes/rtmp_module_spec.rb
+++ b/spec/unit/recipes/rtmp_module_spec.rb
@@ -1,11 +1,11 @@
 # encoding: utf-8
 
 describe 'nginx::rtmp_module' do
-  
+
   before do
     stub_command('which nginx').and_return(nil)
   end
-  
+
   cached(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['nginx']['source']['modules'] = ['nginx::rtmp_module']

--- a/spec/unit/recipes/rtmp_module_spec.rb
+++ b/spec/unit/recipes/rtmp_module_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 describe 'nginx::rtmp_module' do
-
   before do
     stub_command('which nginx').and_return(nil)
   end

--- a/spec/unit/recipes/rtmp_module_spec.rb
+++ b/spec/unit/recipes/rtmp_module_spec.rb
@@ -1,6 +1,11 @@
 # encoding: utf-8
 
 describe 'nginx::rtmp_module' do
+  
+  before do
+    stub_command('which nginx').and_return(nil)
+  end
+  
   cached(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['nginx']['source']['modules'] = ['nginx::rtmp_module']

--- a/templates/default/modules/rtmp-hls.erb
+++ b/templates/default/modules/rtmp-hls.erb
@@ -1,0 +1,17 @@
+server {
+    listen      <%= node['nginx']['rtmp']['hls_port'] -%>;
+    access_log  <%= node['nginx']['log_dir'] %>/rtmp_hls.access.log;
+
+    <% if node['nginx']['rtmp']['hls'] %>
+    location /hls {
+        # Serve HLS fragments
+        types {
+            application/vnd.apple.mpegurl m3u8;
+            video/mp2t ts;
+        }
+        alias /tmp/hls/;
+        add_header Cache-Control no-cache;
+        expires -1;
+    }
+    <% end %>
+}

--- a/templates/default/modules/rtmp-http.erb
+++ b/templates/default/modules/rtmp-http.erb
@@ -1,6 +1,6 @@
 server {
-    listen      <%= node['nginx']['rtmp']['hls_port'] -%>;
-    access_log  <%= node['nginx']['log_dir'] %>/rtmp_hls.access.log;
+    listen      <%= node['nginx']['rtmp']['http_port'] -%>;
+    access_log  <%= node['nginx']['log_dir'] %>/rtmp_http.access.log;
 
     <% if node['nginx']['rtmp']['hls'] %>
     location /hls {
@@ -12,6 +12,13 @@ server {
         alias /tmp/hls/;
         add_header Cache-Control no-cache;
         expires -1;
+    }
+    <% end %>
+    <% if node['nginx']['rtmp']['dash'] %>
+    location /dash {
+        # Serve DASH fragments
+        root /tmp;
+        add_header Cache-Control no-cache;
     }
     <% end %>
 }

--- a/templates/default/modules/rtmp-stat.erb
+++ b/templates/default/modules/rtmp-stat.erb
@@ -1,0 +1,19 @@
+server {
+    listen      <%= node['nginx']['rtmp']['stat_port'] -%>;
+    access_log  <%= node['nginx']['log_dir'] %>/rtmp_stat.access.log;
+
+    <% if node['nginx']['rtmp']['stat'] %>
+    # This URL provides RTMP statistics in XML
+    location /stat {
+        rtmp_stat all;
+        rtmp_stat_stylesheet stat.xsl;
+    }
+
+    location /stat.xsl {
+        # XML stylesheet to view RTMP stats.
+        # Copy stat.xsl wherever you want
+        # and put the full directory path here
+        root   <%= node['nginx']['rtmp']['stat_root'] %>;
+    }
+    <% end %>
+}

--- a/templates/default/modules/rtmp.conf.erb
+++ b/templates/default/modules/rtmp.conf.erb
@@ -13,12 +13,18 @@ rtmp {
         application live {
              live on;
              idle_streams off;
+             <% if node['nginx']['rtmp']['hls'] then %>
              hls on;
              hls_path /tmp/hls;
              hls_fragment 5s;
              hls_playlist_length 60s;
              hls_sync 5ms;
              hls_type live;
+             <% end %>
+             <% if node['nginx']['rtmp']['dash'] then %>
+             dash on;
+             dash_path /tmp/dash;
+             <% end %>
              allow play all;
        }
     }

--- a/templates/default/modules/rtmp.conf.erb
+++ b/templates/default/modules/rtmp.conf.erb
@@ -1,0 +1,17 @@
+rtmp {
+    server {
+        listen <%=node['nginx']['rtmp']['rtmp_port']%>;
+        chunk_size 4000;
+        application live {
+             live on;
+             idle_streams off;
+             hls on;
+             hls_path /tmp/hls;
+             hls_fragment 5s;
+             hls_playlist_length 60s;
+             hls_sync 5ms;
+             hls_type live;
+             allow play all;
+       }
+    }
+}

--- a/templates/default/modules/rtmp.conf.erb
+++ b/templates/default/modules/rtmp.conf.erb
@@ -1,6 +1,14 @@
 rtmp {
     server {
         listen <%=node['nginx']['rtmp']['rtmp_port']%>;
+        <% 
+        if node['nginx']['rtmp'].key?('publishers') then
+          [*node['nginx']['rtmp']['publishers']].each do |p|
+        %>
+        allow publish <%=p%>;
+        <%  end %>
+        deny publish all;
+        <% end %>
         chunk_size 4000;
         application live {
              live on;

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -23,6 +23,10 @@ events {
 <% end -%>
 }
 
+<% if node['nginx']['rtmp']['rtmp_server'] %>
+include       <%= node['nginx']['dir'] %>/rtmp.conf;
+
+<% end %>
 http {
   <% if node.recipe?('nginx::naxsi_module') %>
   include       <%= node['nginx']['dir'] %>/naxsi_core.rules;

--- a/test/integration/modules/serverspec/rtmp_module_spec.rb
+++ b/test/integration/modules/serverspec/rtmp_module_spec.rb
@@ -1,0 +1,11 @@
+# Encoding: utf-8
+require_relative 'spec_helper'
+
+# FIXME: This will not sustain a version update
+describe command('/opt/nginx-1.6.2/sbin/nginx -V') do
+  its(:stdout) { should match(/rtmp/) }
+end
+
+describe service('nginx') do
+  it { should be_running }
+end


### PR DESCRIPTION
Only supporting 1 RTMP application currently, HLS support, no DASH support yet.  Tested and working, running on my rtmp cluster currently.