### PR TITLE
test configure_flags with bash variable interpolation before recompiling

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -109,7 +109,7 @@ bash 'compile_nginx_source' do
     nginx_force_recompile == false &&
       node.automatic_attrs['nginx'] &&
       node.automatic_attrs['nginx']['version'] == node['nginx']['source']['version'] &&
-      node.automatic_attrs['nginx']['configure_arguments'].sort == configure_flags.sort
+      node.automatic_attrs['nginx']['configure_arguments'].sort == configure_flags.map{|f| `echo "#{f}"`.strip}.sort
   end
 
   notifies :restart, 'service[nginx]'


### PR DESCRIPTION
to avoid rebuilding in cases where configure_flags are specified with bash variables

e.g.

override['nginx']['configure_flags'] = [
  '--add-module=$(passenger-config --root | xargs echo)/ext/nginx'
]