### PR TITLE
Specify access_log and error_log manually, supports things like syslog

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,7 +113,9 @@ default['nginx']['underscores_in_headers'] = nil
 default['nginx']['tcp_nodelay'] = 'on'
 default['nginx']['tcp_nopush'] = 'on'
 
+default['nginx']['access_log'] = "#{node['nginx']['log_dir']}/access.log"
 default['nginx']['access_log_options']     = nil
+default['nginx']['error_log'] = "#{node['nginx']['log_dir']}/error.log"
 default['nginx']['error_log_options']      = nil
 default['nginx']['disable_access_log']     = false
 default['nginx']['log_formats']            = {}

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -7,7 +7,7 @@ daemon off;
 worker_rlimit_nofile <%= node['nginx']['worker_rlimit_nofile'] %>;
 <% end -%>
 
-error_log  <%= node['nginx']['log_dir'] %>/error.log<% if node['nginx']['error_log_options'] %> <%= node['nginx']['error_log_options'] %><% end %>;
+error_log  <%= node['nginx']['error_log'] %><% if node['nginx']['error_log_options'] %> <%= node['nginx']['error_log_options'] %><% end %>;
 pid        <%= node['nginx']['pid'] %>;
 
 events {
@@ -38,7 +38,7 @@ http {
   <% if node['nginx']['disable_access_log'] -%>
   access_log    off;
   <% else -%>
-  access_log    <%= node['nginx']['log_dir'] %>/access.log<% if node['nginx']['access_log_options'] %> <%= node['nginx']['access_log_options'] %><% end %>;
+  access_log    <%= node['nginx']['access_log'] %><% if node['nginx']['access_log_options'] %> <%= node['nginx']['access_log_options'] %><% end %>;
   <% end %>
   <% if node['nginx']['server_tokens'] -%>
   server_tokens <%= node['nginx']['server_tokens'] %>;

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -32,7 +32,7 @@ http {
   default_type  application/octet-stream;
 
   <% node['nginx']['log_formats'].each do |name, format| %>
-  log_format <%= name %> <%= format %>;
+  log_format <%= name %> '<%= format %>';
   <% end -%>
 
   <% if node['nginx']['disable_access_log'] -%>


### PR DESCRIPTION
This allows to use the syslog syntax:
```
access_log syslog:server=localhost:5567 custom_log_format
```

Furthermore, `log_format` should be escaped by default, to prevent the user from having to double-escape the format string.
