### PR TITLE
allow more control in access_log

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -37,6 +37,10 @@ http {
 
   <% if node['nginx']['disable_access_log'] -%>
   access_log    off;
+  <% elsif node['nginx']['access_log'] -%>
+    <% node['nginx']['access_log'].each do |access_log| %>
+  access_log <%= access_log %>;
+    <% end -%>
   <% else -%>
   access_log    <%= node['nginx']['log_dir'] %>/access.log<% if node['nginx']['access_log_options'] %> <%= node['nginx']['access_log_options'] %><% end %>;
   <% end %>


### PR DESCRIPTION
This give more options to customize the access_log setting, a very common scenarion is to send access log to syslog in addition to a file as follows:

```ruby
override['nginx']['access_log'] = [
  "/var/log/nginx/access.log acc_log",
  "syslog:server=localhost:10514 acc_log"
]
```

This change keeps backward compatibility with the other configuration format `log_dir` and `access_log_options`.