### PR TITLE
Use cached source tarball if it exists instead of redownloading every time.

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -55,7 +55,7 @@ packages.each do |name|
   package name
 end
 
-remote_file nginx_url do
+remote_file src_filepath do
   source   nginx_url
   checksum node['nginx']['source']['checksum']
   path     src_filepath


### PR DESCRIPTION
Changes line 58, source.rb, from `remote_file nginx_url do` to `remote_file src_filepath do`. 

This change causes chef to first check the file cache for a valid source tarball before attempting to download the nginx source. Previously this line forced a download of source tarball even if there was a checksum-valid file at `src_filepath` as this was never checked, only written to. 

Several of our servers have already been hellbanned by the nginx download server (download connection is reset by remote after a few bytes are read) due to constantly re-downloading this file every time chef-client is run. 