### PR TITLE
Add --no-same-owner flag to the (u)tar command

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -85,7 +85,7 @@ package 'tar'
 bash 'unarchive_source' do
   cwd  ::File.dirname(src_filepath)
   code <<-EOH
-    tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
+    tar zxf #{::File.basename(src_filepath)} --no-same-owner -C #{::File.dirname(src_filepath)}
   EOH
   not_if { ::File.directory?("#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['source']['version']}") }
 end


### PR DESCRIPTION
I have an issue with untarring the Nginx source. I get the following error log:

    ==> vm: * bash[unarchive_source] action run
    ==> vm:     
    ==> vm: 
    ==> vm:     
    ==> vm: ================================================================================
    ==> vm:     
    ==> vm: Error executing action `run` on resource 'bash[unarchive_source]'
    ==> vm:     
    ==> vm: ================================================================================
    ==> vm:     
    ==> vm: 
    ==> vm: 
    ==> vm:     
    ==> vm: Mixlib::ShellOut::ShellCommandFailed
    ==> vm:     
    ==> vm: ------------------------------------
    ==> vm:     
    ==> vm: Expected process to exit with [0], but received '2'
    ==> vm: 
    ==> vm:     
    ==> vm: ---- Begin output of "bash"  "/tmp/chef-script20150805-7431-19ty08y" ----
    ==> vm: 
    ==> vm:     STDOUT: 
    ==> vm:     STDERR: tar: nginx-1.6.3/auto: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/contrib: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/configure: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/LICENSE: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/README: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/html: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/man: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/CHANGES.ru: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/CHANGES: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/man/nginx.8: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/html/50x.html: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/html/index.html: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/core: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/event: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/misc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_aio_read_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_aio_read.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_aio_write_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_aio_write.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_atomic.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_alloc.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_alloc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_darwin_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_channel.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_channel.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_daemon.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_darwin.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_darwin_sendfile_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_darwin_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_file_aio_read.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_errno.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_errno.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_freebsd.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_files.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_files.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_freebsd_rfork_thread.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_freebsd_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_freebsd_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_freebsd_sendfile_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_freebsd_rfork_thread.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_sparc64.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_amd64.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_ppc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_solaris_sendfilev_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_x86.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_linux.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_linux_aio_read.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_linux_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_linux_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_linux_sendfile_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_os.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_posix_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_posix_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_process.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_process.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_process_cycle.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_process_cycle.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_pthread_thread.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_readv_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_recv.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_send.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_setaffinity.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_setaffinity.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_setproctitle.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_setproctitle.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_shmem.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_shmem.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_socket.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_socket.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_solaris.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_solaris_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_solaris_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_sunpro_atomic_sparc64.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_sunpro_amd64.il: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_sunpro_sparc64.il: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_sunpro_x86.il: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_thread.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_time.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_time.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_udp_recv.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_user.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_user.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/ngx_writev_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix/rfork_thread.S: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os/unix: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/os: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/misc/ngx_google_perftools_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/misc/ngx_cpp_test_module.cpp: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_auth_http_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_core_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_imap_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_imap_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_imap_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_parse.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_pop3_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_pop3_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_pop3_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_proxy_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_smtp_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_smtp_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_smtp_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_ssl_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/mail/ngx_mail_ssl_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_cache.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_copy_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_busy_lock.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_busy_lock.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_header_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_core_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_core_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_file_cache.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_parse_time.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_parse.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_request_body.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_request.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_postpone_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_request.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_spdy_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_script.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_script.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_spdy.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_spdy.h: Cannot change ownership to uid 100
    ==> vm: 1, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_spdy_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_spdy_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_special_response.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_upstream.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_upstream.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_upstream_round_robin.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_upstream_round_robin.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_variables.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_variables.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/ngx_http_write_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_addition_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_access_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_charset_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_auth_basic_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_auth_request_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_autoindex_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_browser_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_not_modified_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_chunked_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_dav_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_degradation_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_empty_gif_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_fastcgi_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_flv_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_geo_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_geoip_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_gunzip_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_gzip_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_gzip_static_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_headers_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_image_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_index_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_limit_conn_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_limit_req_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_log_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_map_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_memcached_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_mp4_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_random_index_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_proxy_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_upstream_ip_hash_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_range_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_realip_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_referer_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_rewrite_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_scgi_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_secure_link_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_split_clients_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_ssi_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/perl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_ssi_filter_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_ssl_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_ssl_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_static_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_stub_status_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_sub_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/src/http/modules/ngx_http_upstream_keepalive_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_upstream_least_conn_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_userid_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_uwsgi_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_xslt_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/Makefile.PL: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/nginx.pm: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/nginx.xs: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/typemap: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/ngx_http_perl_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/ngx_http_perl_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_accept.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_openssl_stapling.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_busy_lock.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_busy_lock.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_connect.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_connect.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_mutex.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_openssl.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_openssl.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_pipe.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_pipe.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_posted.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_posted.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_timer.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_timer.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_devpoll_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_aio_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_eventport_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_epoll_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_win32_select_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_kqueue_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_poll_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_rtsig_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_select_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_array.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/nginx.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/nginx.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_conf_file.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_array.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_buf.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_buf.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_connection.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_conf_file.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_murmurhash.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_file.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_connection.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_core.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_cpuinfo.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crc32.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crc32.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crypt.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crypt.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_cycle.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_cycle.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_file.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_hash.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_hash.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_inet.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_inet.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_list.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_list.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_log.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_log.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_md5.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_md5.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_open_file_cache.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_murmurhash.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_open_file_cache.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_output_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_palloc.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_palloc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_parse.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_parse.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_proxy_protocol.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_proxy_protocol.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_queue.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_queue.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_radix_tree.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_radix_tree.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_rbtree.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_rbtree.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_regex.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_regex.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_resolver.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_resolver.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_sha1.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_shmtx.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_shmtx.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_slab.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_slab.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_spinlock.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_string.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_string.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_times.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/src/core/ngx_times.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/geo2nginx.pl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/README: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim/ftdetect: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim/indent: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim/syntax/nginx.vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim/syntax: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim/indent/nginx.vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim/ftdetect/nginx.vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx/koi-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx/win-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx/unicode-to-nginx.pl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/fastcgi.conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/fastcgi_params: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/koi-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/koi-win: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/mime.types: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/nginx.conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/scgi_params: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/uwsgi_params: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/conf/win-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/cc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/have_headers: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/define: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/endianness: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/feature: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/have: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/headers: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/include: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/init: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/install: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/types: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/modules: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/nohave: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/options: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/sources: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/stubs: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/summary: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/unix: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/types/uintptr_t: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/types/sizeof: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/types/typedef: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/types/value: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os/darwin: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os/freebsd: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os/linux: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os/solaris: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/os/win32: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/geoip: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/google-perftools: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/libatomic: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/libgd: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/libxslt: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/md5: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/openssl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/perl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/test: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/patch.zlib.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/perl/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/perl/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: 
    ==> vm:     tar: nginx-1.6.3/auto/lib/pcre/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/pcre/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/pcre/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/pcre/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/openssl/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/openssl/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/openssl/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/openssl/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/md5/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/md5/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/md5/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/md5/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/md5/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/libxslt/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/libgd/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/libatomic/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/libatomic/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/google-perftools/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/lib/geoip/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/clang: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/acc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/ccc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/gcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/icc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/name: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3/auto/cc/sunc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: nginx-1.6.3: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm:     tar: Exiting with failure status due to previous errors
    ==> vm:     ---- End output of "bash"  "/tmp/chef-script20150805-7431-19ty08y" ----
    ==> vm:     Ran "bash"  "/tmp/chef-script20150805-7431-19ty08y" returned 2
    ==> vm:     
    ==> vm:     Resource Declaration:
    ==> vm:     ---------------------
    ==> vm:     # In /tmp/vagrant-chef/1bf6f86343592db6a07c1f357dd401cc/cookbooks/nginx/recipes/source.rb
    ==> vm:     
    ==> vm:      82: bash 'unarchive_source' do
    ==> vm:      83:   cwd  ::File.dirname(src_filepath)
    ==> vm:      84:   code <<-EOH
    ==> vm:      85:     tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
    ==> vm:      86:   EOH
    ==> vm:      87:   not_if { ::File.directory?("#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['source']['version']}") }
    ==> vm:      88: end
    ==> vm:      89: 
    ==> vm:     
    ==> vm:     Compiled Resource:
    ==> vm:     ------------------
    ==> vm:     # Declared in /tmp/vagrant-chef/1bf6f86343592db6a07c1f357dd401cc/cookbooks/nginx/recipes/source.rb:82:in `from_file'
    ==> vm:     
    ==> vm:     bash("unarchive_source") do
    ==> vm:       action [:run]
    ==> vm:       retries 0
    ==> vm:       retry_delay 2
    ==> vm:       default_guard_interpreter :default
    ==> vm:       command "unarchive_source"
    ==> vm:       backup 5
    ==> vm:       cwd "/var/chef/cache"
    ==> vm:       returns 0
    ==> vm:       code "    tar zxf nginx-1.6.3.tar.gz -C /var/chef/cache\n"
    ==> vm:       interpreter "bash"
    ==> vm:       declared_type :bash
    ==> vm:       cookbook_name :nginx
    ==> vm:       recipe_name "source"
    ==> vm:       not_if { #code block }
    ==> vm:     end
    ==> vm:     
    ==> vm: [2015-08-05T08:24:17+00:00] INFO: Running queued delayed notifications before re-raising exception
    ==> vm: [2015-08-05T08:24:17+00:00] INFO: template[nginx.conf] sending reload action to service[nginx] (delayed)
    ==> vm: Recipe: nginx::default
    ==> vm:   * service[nginx] action reload
    ==> vm:  (up to date)
    ==> vm: 
    ==> vm: Running handlers:
    ==> vm: [2015-08-05T08:24:17+00:00] ERROR: Running exception handlers
    ==> vm: Running handlers complete
    ==> vm: 
    ==> vm: [2015-08-05T08:24:17+00:00] ERROR: Exception handlers complete
    ==> vm: Chef Client failed. 8 resources updated in 12.670740744 seconds
    ==> vm: [2015-08-05T08:24:17+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
    ==> vm: [2015-08-05T08:24:17+00:00] ERROR: bash[unarchive_source] (nginx::source line 82) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '2'
    ==> vm: ---- Begin output of "bash"  "/tmp/chef-script20150805-7431-19ty08y" ----
    ==> vm: STDOUT: 
    ==> vm: STDERR: tar: nginx-1.6.3/auto: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/configure: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/LICENSE: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/README: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/html: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/man: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/CHANGES.ru: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/CHANGES: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/man/nginx.8: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/html/50x.html: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/html/index.html: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/misc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_aio_read_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_aio_read.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_aio_write_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_aio_write.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_atomic.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_alloc.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_alloc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_darwin_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_channel.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_channel.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_daemon.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_darwin.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_darwin_sendfile_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_darwin_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_file_aio_read.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_errno.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_errno.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_freebsd.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_files.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_files.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_freebsd_rfork_thread.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_freebsd_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_freebsd_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_freebsd_sendfile_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_freebsd_rfork_thread.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_sparc64.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_amd64.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_ppc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_solaris_sendfilev_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_gcc_atomic_x86.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_linux.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_linux_aio_read.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_linux_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_linux_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_linux_sendfile_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_os.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_posix_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_posix_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_process.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_process.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_process_cycle.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_process_cycle.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_pthread_thread.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_readv_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_recv.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_send.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_setaffinity.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_setaffinity.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_setproctitle.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_setproctitle.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_shmem.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_shmem.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_socket.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_socket.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_solaris.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_solaris_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_solaris_init.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_sunpro_atomic_sparc64.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_sunpro_amd64.il: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_sunpro_sparc64.il: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_sunpro_x86.il: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_thread.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_time.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_time.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_udp_recv.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_user.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_user.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/ngx_writev_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix/rfork_thread.S: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os/unix: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/os: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/misc/ngx_google_perftools_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/misc/ngx_cpp_test_module.cpp: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_auth_http_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_core_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_imap_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_imap_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_imap_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_parse.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_pop3_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_pop3_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_pop3_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_proxy_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_smtp_handler.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_smtp_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_smtp_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_ssl_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/mail/ngx_mail_ssl_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_cache.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_copy_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_busy_lock.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_busy_lock.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_header_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_core_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_core_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_file_cache.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_parse_time.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_parse.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_request_body.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_request.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_postpone_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_request.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_spdy_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_script.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_script.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_spdy.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_spdy.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_spdy_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_spdy_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_special_response.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_upstream.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_upstream.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_upstream_round_robin.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_
    ==> vm: http_upstream_round_robin.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_variables.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_variables.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/ngx_http_write_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_addition_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_access_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_charset_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_auth_basic_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_auth_request_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_autoindex_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_browser_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_not_modified_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_chunked_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_dav_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_degradation_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_empty_gif_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_fastcgi_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_flv_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_geo_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_geoip_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_gunzip_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_gzip_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_gzip_static_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_headers_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_image_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_index_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_limit_conn_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_limit_req_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_log_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_map_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_memcached_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_mp4_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_random_index_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_proxy_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_upstream_ip_hash_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_range_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_realip_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_referer_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_rewrite_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_scgi_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_secure_link_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_split_clients_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_ssi_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_ssi_filter_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_ssl_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_ssl_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_static_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_stub_status_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_sub_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_upstream_keepalive_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_upstream_least_conn_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_userid_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_uwsgi_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/ngx_http_xslt_filter_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/Makefile.PL: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/nginx.pm: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/nginx.xs: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/typemap: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/ngx_http_perl_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/http/modules/perl/ngx_http_perl_module.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_accept.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_openssl_stapling.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_busy_lock.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_busy_lock.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_connect.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_connect.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_mutex.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_openssl.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_openssl.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_pipe.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_pipe.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_posted.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_posted.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_timer.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/ngx_event_timer.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_devpoll_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_aio_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_eventport_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_epoll_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_win32_select_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_kqueue_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_poll_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_rtsig_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/event/modules/ngx_select_module.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_array.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/nginx.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/nginx.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_conf_file.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_array.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_buf.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_buf.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_connection.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_conf_file.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_config.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_murmurhash.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_file.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_connection.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_core.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_cpuinfo.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crc32.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crc32.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crypt.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_crypt.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_cycle.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_cycle.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_file.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_hash.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_hash.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_inet.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_inet.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_list.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_list.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_log.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_log.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_md5.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_md5.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_open_file_cache.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_murmurhash.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_open_file_cache.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_output_chain.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_palloc.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_palloc.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_parse.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_parse.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_proxy_protocol.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_proxy_protocol.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_queue.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_queue.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_radix_tree.c: Cannot change ownership to uid 1001, gid 1001
    ==> vm: : Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_radix_tree.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_rbtree.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_rbtree.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_regex.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_regex.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_resolver.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_resolver.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_sha1.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_shmtx.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_shmtx.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_slab.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_slab.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_spinlock.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_string.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_string.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_times.c: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/src/core/ngx_times.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/geo2nginx.pl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/README: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim/ftdetect: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim/indent: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim/syntax/nginx.vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim/syntax: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim/indent/nginx.vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim/ftdetect/nginx.vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/vim: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx/koi-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx/win-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/contrib/unicode2nginx/unicode-to-nginx.pl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/fastcgi.conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/fastcgi_params: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/koi-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/koi-win: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/mime.types: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/nginx.conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/scgi_params: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/uwsgi_params: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/conf/win-utf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/have_headers: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/define: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/endianness: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/feature: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/have: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/headers: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/include: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/init: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/install: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/types: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/modules: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/nohave: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/options: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/sources: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/stubs: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/summary: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/unix: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/types/uintptr_t: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/types/sizeof: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/types/typedef: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/types/value: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os/darwin: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os/freebsd: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os/linux: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os/solaris: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/os/win32: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/geoip: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/google-perftools: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libatomic: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libgd: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libxslt: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/md5: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/openssl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/perl: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/test: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/zlib/patch.zlib.h: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/sha1/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/perl/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/perl/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/pcre/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/openssl/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/openssl/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/openssl/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/openssl/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/md5/makefile.bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/md5/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/md5/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/md5/makefile.msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/md5/makefile.owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libxslt/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libgd/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libatomic/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/libatomic/make: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/google-perftools/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/lib/geoip/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/clang: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/acc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/bcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/ccc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/conf: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/gcc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/icc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/msvc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/name: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/owc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3/auto/cc/sunc: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: nginx-1.6.3: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
    ==> vm: tar: Exiting with failure status due to previous errors
    ==> vm: ---- End output of "bash"  "/tmp/chef-script20150805-7431-19ty08y" ----
    ==> vm: Ran "bash"  "/tmp/chef-script20150805-7431-19ty08y" returned 2
    ==> vm: [2015-08-05T08:24:17+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
    Chef never successfully completed! Any errors should be visible in the
    output above. Please fix your recipes so that they properly complete.

I found out that the `cache` directory is owned by the `vagrant` user. Probably because I use the [Vagrant cachier plugin](https://github.com/fgrehm/vagrant-cachier).
See more details below:

    $ ls -al /var/chef
    total 12
    drwxr-xr-x  3 root    root 4096 Aug  4 18:56 ./
    drwxr-xr-x 13 root    root 4096 Aug  4 18:55 ../
    drwxr-xr-x  3 vagrant root 4096 Aug  4 18:56 backup/
    lrwxrwxrwx  1 vagrant root   23 Aug  4 18:55 cache -> /tmp/vagrant-cache/chef/

This ownership is causing the `Cannot change ownership to uid 1001, gid 1001: Operation not permitted` issue.

Thanks to [this post](https://www.krenger.ch/blog/linux-tar-cannot-change-ownership-to-permission-denied/) I found out that, the following command to extract the tar everything works fine:

    tar zxf nginx-1.6.3.tar.gz --no-same-owner -C /var/chef/cache