### PR TITLE
Force nginx to start at the end of the run.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ include_recipe "nginx::#{node['nginx']['install_method']}"
 
 service 'nginx' do
   supports :status => true, :restart => true, :reload => true
-  action   :nothing
+  action   :enable
   notifies :start, 'service[nginx]', :delayed
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,8 @@ include_recipe "nginx::#{node['nginx']['install_method']}"
 
 service 'nginx' do
   supports :status => true, :restart => true, :reload => true
-  action   :start
+  action   :nothing
+  notifies :start, 'service[nginx]', :delayed
 end
 
 node['nginx']['default']['modules'].each do |ngx_module|

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -10,8 +10,9 @@ describe 'nginx::default' do
   end
 
   shared_examples_for 'default recipe' do
-    it 'starts the service' do
-      expect(chef_run).to start_service('nginx')
+    it 'enables the service and start it delayed' do
+      expect(chef_run).to enable_service('nginx')
+      expect(chef_run.service('nginx')).to notify('service[nginx]').to(:start).delayed
     end
   end
 


### PR DESCRIPTION
Lets say that my_site.conf has an error in it.
On the first run, the nginx default recipe, via include_recipe, will install and start nginx. Then we install a template file to configure and enable a site that notifies a restart of nginx. Now nginx will fail to restart because of the error and the chef run will end.
So we go back and we look at my_site.conf and realize it has a typo. We fix it and re-upload the cookbook and run Chef again. The nginx default recipe runs again, trying to start nginx (default recipe have this action). This will fail here, because the configuration file is still broken, which will end the chef run, never giving our template resource the opportunity to fix the configuration file.
Perhaps we move our template above the include_recipe in our cookbook. This works now and we go home happy, but the next time we try to build a server from scratch this fails because the /etc/nginx/sites-available directory does not exist until nginx is installed.
Thus, my fix is to delay the start of nginx until the end of the run. This wouldn't work if you needed nginx to be started for some reason during the chef run, but I'm not sure of that use case.

Similar problem with apache in the past: https://tickets.opscode.com/browse/COOK-58