### PR TITLE
Use node.override for source binary attribute.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ group :lint do
 end
 
 group :unit do
-  gem 'berkshelf', '~> 3.2.0'
-  gem 'chefspec',  '~> 4.1.0'
+  gem 'berkshelf', '~> 4.0'
+  gem 'chefspec',  '~> 4.3.0'
 end
 
 group :kitchen_common do

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
 depends 'ohai',            '~> 2.0'
-depends 'runit',           '~> 1.2'
+depends 'runit',           '~> 1.7'
 depends 'yum-epel',        '~> 0.3'
 
 supports 'amazon'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ depends 'apt',             '~> 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
 depends 'ohai',            '~> 2.0'
-depends 'runit',           '~> 1.7'
+depends 'runit',           '1.7.4'
 depends 'yum-epel',        '~> 0.3'
 
 supports 'amazon'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -28,7 +28,7 @@ node.load_attribute_by_short_filename('source', 'nginx') if node.respond_to?(:lo
 nginx_url = node['nginx']['source']['url'] ||
             "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
 
-node.set['nginx']['binary']          = node['nginx']['source']['sbin_path']
+node.override['nginx']['binary']     = node['nginx']['source']['sbin_path']
 node.set['nginx']['daemon_disable']  = true
 
 unless node['nginx']['source']['use_existing_user']


### PR DESCRIPTION
This fixes an issue when using source install and runit where an incorrect sbin_path is used in /templates/default/sv-nginx-run.erb.

This may solve #342.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/378)
<!-- Reviewable:end -->
