### PR TITLE
Add utf8 output to Geo modules

### DIFF
--- a/templates/default/modules/http_geoip.conf.erb
+++ b/templates/default/modules/http_geoip.conf.erb
@@ -1,4 +1,4 @@
-geoip_country <%= @country_dat %>;
+geoip_country <%= @country_dat %> utf8;
 <% if @city_dat -%>
-geoip_city <%= @city_dat %>;
+geoip_city <%= @city_dat %> utf8;
 <% end -%>


### PR DESCRIPTION
Otherwise, countries and cities with accent, like "Montréal" aren't outputting correctly. See http://stackoverflow.com/questions/32356640/maxmind-geoip-city-encoding-issue/32360383#32360383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/380)
<!-- Reviewable:end -->
