### PR TITLE
Passenger: set module source path correctly for Passenger 5

### DIFF
--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -42,8 +42,14 @@ elsif node['nginx']['passenger']['install_method'] == 'source'
     gem_binary node['nginx']['passenger']['gem_binary'] if node['nginx']['passenger']['gem_binary']
   end
 
+  if Chef::VersionConstraint.new(">= 5.0.0").include?(node['nginx']['passenger']['version'])
+    module_src_path = 'src/nginx_module'
+  else
+    module_src_path = 'ext/nginx'
+  end
+
   node.run_state['nginx_configure_flags'] =
-    node.run_state['nginx_configure_flags'] | ["--add-module=#{node['nginx']['passenger']['root']}/ext/nginx"]
+    node.run_state['nginx_configure_flags'] | ["--add-module=#{node['nginx']['passenger']['root']}/#{module_src_path}"]
 
 end
 


### PR DESCRIPTION
Passenger 5 changed the location of its nginx module source, so Nginx fails to compile with Passenger 5. This fixes #360 — for me anyway.

Note that the other pull request on the same topic (inexplicably) does a version check for Passenger >= 5.0.19 — this will break for previous Passenger 5 versions, since the change in module location is at 5.0.0.