### PR TITLE
Use platform family to determine nginx user.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -14,16 +14,16 @@ module NginxCookbook
       new_resource.name
     end
 
-    # @param [Chef::Node] An Object that responds to a `['platform']` call
+    # @param [Chef::Node] An Object that responds to a `['platform_family']` call
     # @return [String] Name of the user that runs nginx
-    def user_for_platform(node)
-      case node['platform']
-      when 'centos'
+    def user_for_node(node)
+      case node['platform_family']
+      when 'rhel'
         'nginx'
-      when 'ubuntu', 'debian'
+      when 'debian'
         'www-data'
       else
-        raise "Unexpected platform '#{node['platform']}'."
+        raise "Unexpected platform family '#{node['platform_family']}'."
       end
     end
   end

--- a/libraries/resource_nginx_service.rb
+++ b/libraries/resource_nginx_service.rb
@@ -14,7 +14,7 @@ class Chef
       attribute :error_log_level, kind_of: String, default: 'warn'
       attribute :run_group, kind_of: String, default: nil
       # @todo Determine what user is correct per-platform
-      attribute :run_user, kind_of: String, default: lazy { user_for_platform(node) }
+      attribute :run_user, kind_of: String, default: lazy { user_for_node(node) }
       attribute :worker_connections, kind_of: Integer, default: 1024
       attribute :worker_processes, kind_of: Integer, default: 1
 

--- a/spec/libraries_specs/helpers_spec.rb
+++ b/spec/libraries_specs/helpers_spec.rb
@@ -2,35 +2,30 @@ require_relative '../../libraries/helpers'
 require_relative '../../libraries/resource_nginx_service'
 
 describe NginxCookbook::Helpers do
-  class DummyClass
-    attr_accessor :node
-
-    def initialize
-      @node = {}
-    end
-  end
-
-  before(:all) do
-    @dummy = DummyClass.new
-    @dummy.extend NginxCookbook::Helpers
-  end
+  include described_class
 
   it 'returns www-data for debian platform' do
-    @dummy.node['platform'] = 'debian'
+    node = Fauxhai.mock(platform: 'debian', version: '7.0').data
 
-    expect(@dummy.user_for_platform(@dummy.node)).to be == 'www-data'
+    expect(user_for_node(node)).to be == 'www-data'
   end
 
   it 'returns www-data for ubuntu platform' do
-    @dummy.node['platform'] = 'ubuntu'
+    node = Fauxhai.mock(platform: 'ubuntu', version: '14.04').data
 
-    expect(@dummy.user_for_platform(@dummy.node)).to be == 'www-data'
+    expect(user_for_node(node)).to be == 'www-data'
   end
 
   it 'returns nginx for centos platform' do
-    @dummy.node['platform'] = 'centos'
+    node = Fauxhai.mock(platform: 'centos', version: '7.0').data
 
-    expect(@dummy.user_for_platform(@dummy.node)).to be == 'nginx'
+    expect(user_for_node(node)).to be == 'nginx'
+  end
+
+  it 'returns nginx for amazon platform' do
+    node = Fauxhai.mock(platform: 'amazon', version: '2015.09').data
+
+    expect(user_for_node(node)).to be == 'nginx'
   end
 
   # # let(:klass) { Class.new { extend NginxCookbook::Helpers } }

--- a/spec/libraries_specs/resource/nginx_service/create/centos_7_spec.rb
+++ b/spec/libraries_specs/resource/nginx_service/create/centos_7_spec.rb
@@ -13,7 +13,7 @@ describe 'resource_nginx_service :create on centos 7' do
 
   it_behaves_like 'create a named nginx_service', 'example'
 
-  it_behaves_like 'nginx_service :create', 'example', 'platform' => 'centos'
+  it_behaves_like 'nginx_service :create', 'example'
   it_behaves_like 'nginx_service :start', 'example'
   it_behaves_like 'nginx_service #systemd', 'example'
 

--- a/spec/libraries_specs/resource/nginx_service/create/debian_7_spec.rb
+++ b/spec/libraries_specs/resource/nginx_service/create/debian_7_spec.rb
@@ -13,7 +13,7 @@ describe 'resource_nginx_service :create on debian 7' do
 
   it_behaves_like 'create a named nginx_service', 'example'
 
-  it_behaves_like 'nginx_service :create', 'example', 'platform' => 'debian'
+  it_behaves_like 'nginx_service :create', 'example'
   it_behaves_like 'nginx_service :start', 'example'
   it_behaves_like 'nginx_service #upstart', 'example'
 

--- a/spec/libraries_specs/resource/nginx_service/create/ubuntu_1404_spec.rb
+++ b/spec/libraries_specs/resource/nginx_service/create/ubuntu_1404_spec.rb
@@ -13,7 +13,7 @@ describe 'resource_nginx_service :create on ubuntu 14.04' do
 
   it_behaves_like 'create a named nginx_service', 'example'
 
-  it_behaves_like 'nginx_service :create', 'example', 'platform' => 'ubuntu'
+  it_behaves_like 'nginx_service :create', 'example'
   it_behaves_like 'nginx_service :start', 'example'
   it_behaves_like 'nginx_service #upstart', 'example'
 

--- a/spec/libraries_specs/resource/nginx_service/delete/centos_7_spec.rb
+++ b/spec/libraries_specs/resource/nginx_service/delete/centos_7_spec.rb
@@ -9,7 +9,7 @@ describe 'resource_nginx_service :delete on centos 7' do
 
   it_behaves_like 'create a named nginx_service', 'single'
 
-  it_behaves_like 'nginx_service :create', 'single', 'platform' => 'centos'
+  it_behaves_like 'nginx_service :create', 'single'
   it_behaves_like 'nginx_service :start', 'single'
 
   xit 'stops the service' do

--- a/spec/libraries_specs/resource/nginx_service/delete/debian_7_spec.rb
+++ b/spec/libraries_specs/resource/nginx_service/delete/debian_7_spec.rb
@@ -9,7 +9,7 @@ describe 'resource_nginx_service :delete on debian 7' do
 
   it_behaves_like 'create a named nginx_service', 'single'
 
-  it_behaves_like 'nginx_service :create', 'single', 'platform' => 'debian'
+  it_behaves_like 'nginx_service :create', 'single'
   it_behaves_like 'nginx_service :start', 'single'
 
   xit 'stops the service' do

--- a/spec/shared_examples/service.rb
+++ b/spec/shared_examples/service.rb
@@ -8,7 +8,7 @@ RSpec.configure do
     end
   end
 
-  shared_examples_for 'nginx_service :create' do |servicename, node|
+  shared_examples_for 'nginx_service :create' do |servicename|
     it 'installs the nginx package' do
       expect(chef_run).to install_package("#{servicename} :create nginx")
         .with(package_name: 'nginx')
@@ -21,7 +21,7 @@ RSpec.configure do
 
     it 'creates new directories for the named instance' do
       expect(chef_run).to create_directory("/var/log/nginx-#{servicename}")
-        .with(user: user_for_platform(node), group: 'adm', mode: 00755)
+        .with(user: user_for_node(chef_run.node), group: 'adm', mode: 00755)
 
       %W(
         /etc/nginx-#{servicename}


### PR DESCRIPTION
This was causing failures on all of the other debian and rhel platforms.

This required some refactoring of several specs.  The per-platform checks could really be DRYed up a lot from here, as the only thing changing between them is the platform and version combinations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/414)
<!-- Reviewable:end -->
