### PR TITLE
Don't reject upstart for all redhat platforms

### DIFF
--- a/libraries/provider_nginx_service_upstart.rb
+++ b/libraries/provider_nginx_service_upstart.rb
@@ -7,8 +7,7 @@ class Chef
       # @author Mike Fiedler <miketheman@gmail.com>
       class NginxServiceUpstart < Chef::Provider::NginxServiceBase
         provides :nginx_service, os: 'linux' do
-          Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart) &&
-            !Chef::Platform::ServiceHelpers.service_resource_providers.include?(:redhat)
+          Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart)
         end if defined?(provides)
 
         action :start do


### PR DESCRIPTION
I assume this rule was here for a reason, but it's not exercised by any
of the specs.  This breaks on Amazon linux, which uses upstart.

I suspect the rule needs to be reworked, i.e. `upstart && !systemd` or
something like that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/415)
<!-- Reviewable:end -->
