### PR TITLE
Fix version comparison

### DIFF
--- a/templates/default/modules/http_realip.conf.erb
+++ b/templates/default/modules/http_realip.conf.erb
@@ -2,6 +2,6 @@
 set_real_ip_from <%= address %>;
 <% end %>
 real_ip_header <%= node['nginx']['realip']['header'] %>;
-<% if node['nginx']['version'] >= '1.2.1' -%>
+<% if ::Gem::Version.new(node['nginx']['version']) >= ::Gem::Version.new('1.2.1') -%>
 real_ip_recursive <%= node['nginx']['realip']['real_ip_recursive'] %>;
 <% end -%>


### PR DESCRIPTION
Versions cannot be simply compared as strings:

```
irb(main):001:0> '1.10.0' > '1.2.1'
=> false
irb(main):002:0> ::Gem::Version.new('1.10.0') > ::Gem::Version.new('1.2.1')
=> true
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/433)
<!-- Reviewable:end -->
